### PR TITLE
Fix error where user_info['emails'] is an empty array

### DIFF
--- a/lib/omniauth/strategies/yahoo.rb
+++ b/lib/omniauth/strategies/yahoo.rb
@@ -22,7 +22,7 @@ module OmniAuth
 
       info do
         primary_email = nil
-        if user_info['emails']
+        if user_info['emails'] && !user_info['emails'].empty?
           email_info    = user_info['emails'].find{|e| e['primary']} || user_info['emails'].first
           primary_email = email_info['handle']
         end


### PR DESCRIPTION
Something happened to yahoo in the past 2-3 days, and emails is now returning an empty array. Going in and getting a new key with full access to everything still doesn't return an email.
